### PR TITLE
don't print iteration numbers

### DIFF
--- a/src/double_description.jl
+++ b/src/double_description.jl
@@ -87,7 +87,6 @@ function double_description{T<:Real}(A::Matrix{T})
     Kᶜ = setdiff(1:m, dd.K)
     while !isempty(Kᶜ)
         i = pop!(Kᶜ)
-        println("iteration $(length(dd.K)+1) of $m")
         # length(dd.K) == 31 && break
         update!(dd, i)
     end


### PR DESCRIPTION
(especially since this causes IJulia to crash when benchmarking due to the large number of lines printed)